### PR TITLE
secure move_uploaded_files params

### DIFF
--- a/examples/image-preview/upload.php
+++ b/examples/image-preview/upload.php
@@ -1,9 +1,17 @@
 <?php
 
-if ( !empty( $_FILES ) ) {
+if ( !empty( $_FILES ) && array_key_exists('file', $_FILES)) {
 
     $tempPath = $_FILES[ 'file' ][ 'tmp_name' ];
-    $uploadPath = dirname( __FILE__ ) . '\uploads\\' . $_FILES[ 'file' ][ 'name' ];
+    $uploadName = $_FILES[ 'file' ][ 'name' ];
+
+    $pattern = '/^([A-z0-9\-_]+[\.]?)?[A-z0-9\-_]+\.(gif|jpg|jpeg|png)$/';
+    if(!preg_match($pattern, $uploadName, $hits)) {
+    	header("HTTP/1.0 400 Bad Request");
+    	exit();
+    }
+
+    $uploadPath = dirname( __FILE__ ) . '/uploads/' . $uploadName;
 
     move_uploaded_file( $tempPath, $uploadPath );
 

--- a/examples/simple/upload.php
+++ b/examples/simple/upload.php
@@ -1,9 +1,17 @@
 <?php
 
-if ( !empty( $_FILES ) ) {
+if ( !empty( $_FILES ) && array_key_exists('file', $_FILES)) {
 
     $tempPath = $_FILES[ 'file' ][ 'tmp_name' ];
-    $uploadPath = dirname( __FILE__ ) . '\uploads\\' . $_FILES[ 'file' ][ 'name' ];
+    $uploadName = $_FILES[ 'file' ][ 'name' ];
+
+    $pattern = '/^([A-z0-9\-_]+[\.]?)?[A-z0-9\-_]+\.(gif|jpg|jpeg|png|txt|pdf|docx|doc|xlsx|xls|mp3|wav|aiff|m4a|opus|m4v|mp4|avi|webm)$/';
+    if(!preg_match($pattern, $uploadName, $hits)) {
+    	header("HTTP/1.0 400 Bad Request");
+    	exit();
+    }
+
+    $uploadPath = dirname( __FILE__ ) . '/uploads/' . $uploadName;
 
     move_uploaded_file( $tempPath, $uploadPath );
 


### PR DESCRIPTION
Deploying to a PHP enabled server allowed attackers to upload arbitrary files to the server when the example files were included (like package managers like Bower do).
