### PR TITLE
Bower.json changes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,9 @@
     "version": "0.3.1",
     "main": "angular-file-upload.js",
     "homepage": "https://github.com/nervgh/angular-file-upload",
-    "ignore": [],
+    "ignore": ["examples"],
     "dependencies": {
-        "angular": "~1.2.0rc.1",
+        "angular": "~1.2.11",
         "es5-shim": "~2.1.0",
         "jquery": "1.8.3"
     },


### PR DESCRIPTION
Hey guys, this is regarding the issue being discussed in #52 [to secure the upload.php].

I added the examples directory to be ignored in bower.json. This way it is not installed under bower_components/ when a user adds angular-file-upload through bower install.
Documentation for Bower ignore  here: http://bower.io/#defining-a-package

I also updated AngularJS dependency to current version (**Angular 1.2.11**) instead of the release candidate.
Let me know if you would prefer the version change be reverted. 
I am currently using angular-file-upload with version 1.2.\* for another app, and it is working great, but I am not using all the features.

Current angular version seen here: https://github.com/angular/angular.js/blob/master/CHANGELOG.md
