### PR TITLE
Enhance 'beforeupload' event

### DIFF
--- a/angular-file-upload.js
+++ b/angular-file-upload.js
@@ -448,11 +448,17 @@ app.factory('$fileUploader', [ '$compile', '$rootScope', '$http', '$window', fun
                 that.trigger('in:complete', xhr, item);
             };
 
-            input.after(form);
-            form.append(input).append(iframe);
-            
+   
             item.submitData = function() {
 
+                input.prop('name', item.alias);
+
+                item.formData.forEach(function(obj) {
+                    angular.forEach(obj, function(value, key) {
+                        form.append(angular.element('<input type="hidden" name="' + key + '" value="' + value + '" />'));
+                    });
+                });
+                
                 form.prop({
                     action: item.url,
                     method: item.method,
@@ -461,13 +467,8 @@ app.factory('$fileUploader', [ '$compile', '$rootScope', '$http', '$window', fun
                     encoding: 'multipart/form-data' // old IE
                 });
                 
-                input.prop('name', item.alias);
-
-                item.formData.forEach(function(obj) {
-                    angular.forEach(obj, function(value, key) {
-                        form.append(angular.element('<input type="hidden" name="' + key + '" value="' + value + '" />'));
-                    });
-                });
+                input.after(form);
+                form.append(input).append(iframe);
 
                 form[ 0 ].submit();    
             };


### PR DESCRIPTION
Hi guys, I'm using your project to upload files directly to S3. However before XHR data can be submited I need to send a callback to my back-end API in order to receive correct credentials for the file. 'beforeupload' event doesn't allow to wait until I receive response from my server. So, I propose to handle response from 'beforeupload' and if it is false then data will be submitted only after explicit call to item.submitData() is made.
