### PR TITLE
Fixed dragleave child elements

### DIFF
--- a/src/scripts/directives/ngFileDrop.js
+++ b/src/scripts/directives/ngFileDrop.js
@@ -33,7 +33,7 @@ app.directive('ngFileDrop', ['$fileUploader', function ($fileUploader) {
                     scope.$broadcast('file:addoverclass');
                 })
                 .bind('dragleave', function (event) {
-                    if(event.target === element[0]) {
+                    if (event.target === element[0]) {
                         scope.$broadcast('file:removeoverclass');
                     }
                 });


### PR DESCRIPTION
We're using your nice module to drag files directly into a library that has many child elements.

We encountered a problem that when you drag the file over a child element it fires the dragleave and dragover events, causing the file class to be removed and added over and over.

We managed to solve this by checking that the target element is the element with the directive.

Not sure if you think this is a problem too but we did :smile:
