### PR TITLE
Check that files really present in dragging data

### DIFF
--- a/angular-file-upload.js
+++ b/angular-file-upload.js
@@ -36,10 +36,12 @@ app.directive('ngFileDrop', ['$fileUploader', function ($fileUploader) {
                         event.dataTransfer :
                         event.originalEvent.dataTransfer; // jQuery fix;
 
-                    event.preventDefault();
-                    event.stopPropagation();
-                    dataTransfer.dropEffect = 'copy';
-                    scope.$broadcast('file:addoverclass');
+                    if(dataTransfer.types && dataTransfer.types.contains('Files')) {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        dataTransfer.dropEffect = 'copy';
+                        scope.$broadcast('file:addoverclass');
+                    }
                 })
                 .bind('dragleave', function (event) {
                     if (event.target === element[0]) {


### PR DESCRIPTION
According to http://www.w3.org/TR/2010/WD-html5-20101019/dnd.html#dom-datatransfer-types we can check that dragged data contains files. If there are no files we should not show drop area.

My use case is as follow.
I need a drag-n-drop file upload but at the same time I need drag-n-drop of another items on the page.
At the moment during dragging of even text the drop file area is shown.
