### PR TITLE
Always upload using item's upload() method.

### DIFF
--- a/src/scripts/services/$fileUploader.js
+++ b/src/scripts/services/$fileUploader.js
@@ -210,7 +210,7 @@ app.factory('$fileUploader', ['$compile', '$rootScope', '$http', '$window', func
                 item.index = item.index || this._nextIndex++;
                 item.isReady = true;
             }, this);
-            items.length && this.uploadItem(items[0]);
+            items.length && items[0].upload();
         },
 
         /**
@@ -302,7 +302,7 @@ app.factory('$fileUploader', ['$compile', '$rootScope', '$http', '$window', func
             this.isUploading = false;
 
             if(angular.isDefined(item)) {
-                this.uploadItem(item);
+                item.upload();
                 return;
             }
 


### PR DESCRIPTION
This allows to re-define item's upload function and perform some actions before item upload (as described in https://github.com/nervgh/angular-file-upload/issues/22).
Can be usefull while uploading to S3 because we need to perform some initial query to get upload url and upload parameters.
