### PR TITLE
fix compatibility error with chrome and safari when dragging file to dropzone

### DIFF
--- a/angular-file-upload.js
+++ b/angular-file-upload.js
@@ -36,11 +36,25 @@ app.directive('ngFileDrop', ['$fileUploader', function ($fileUploader) {
                         event.dataTransfer :
                         event.originalEvent.dataTransfer; // jQuery fix;
 
-                    if(dataTransfer.types && dataTransfer.types.contains('Files')) {
+                    var handleDragover = function(){
                         event.preventDefault();
                         event.stopPropagation();
                         dataTransfer.dropEffect = 'copy';
                         scope.$broadcast('file:addoverclass');
+                    };
+
+                    if(dataTransfer.types) {
+                        try {
+			    //works in chrome, safari
+                            if(dataTransfer.types.indexOf('Files') != -1){
+                                handleDragover();
+                            }
+                        } catch(E){
+			    //works in firefox
+                            if(dataTransfer.types.contains('Files')){
+                                handleDragover();
+                            }
+                        }
                     }
                 })
                 .bind('dragleave', function (event) {


### PR DESCRIPTION
When dragging a file into the dropzone in chrome an undefined error occurred. This meant any user would be unable to drag files into the dropzone. This was because dataTransfer.types.contains is undefined in chrome and safari, however it is defined in firefox. In firefox dataTransfer.types is a DOMStringList, in chrome it is an Array.
