### PR TITLE
fix #171 - prevent console errors when using AMD and angular isn't global

### DIFF
--- a/src/scripts/intro.js
+++ b/src/scripts/intro.js
@@ -6,4 +6,4 @@
     } else {
         return factory(angular);
     }
-}(typeof angular === 'undefined' ? null : angular || null, function(angular) {
+}(typeof angular === 'undefined' ? null : angular, function(angular) {


### PR DESCRIPTION
Adjusted the `angular` parameter to the IIAF in the intro to prevent some browsers from squawking when using an AMD loader like RequireJS where angular is not a global. 

Wasn't sure whether to rebuild or not, since it seemed to be causing more changes to the compiled files than I expected. Figured I'd play it safe.
