### PR TITLE
Added placeholder for console info to fix example error in IE9

### DIFF
--- a/examples/image-preview/controllers.js
+++ b/examples/image-preview/controllers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+if (!window.console) window.console = {};
+if (!window.console.info) window.console.info = function () { };
 
 angular
 

--- a/examples/simple/controllers.js
+++ b/examples/simple/controllers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+if (!window.console) window.console = {};
+if (!window.console.info) window.console.info = function () { };
 
 angular
 

--- a/examples/without-bootstrap/controllers.js
+++ b/examples/without-bootstrap/controllers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+if (!window.console) window.console = {};
+if (!window.console.info) window.console.info = function () { };
 
 angular
 


### PR DESCRIPTION
The examples are currently throwing error and simply not working in IE9 (probably 8 too) if you have not opened the development tools yet. Probable cause of this is that [console.info is undefined](http://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function) until you open up the development tools the first time during the application session.

Fixed this by adding a "shim" for console.info() in the examples, have not tested the fix though since I am too lazy to setup a local server (and github pages for my fork did not work).
