### PR TITLE
Add rubygem to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ You could find this module in bower like [_angular file upload_](http://bower.io
 2. [Module API](https://github.com/nervgh/angular-file-upload/wiki/Module-API)
 3. [FAQ](https://github.com/nervgh/angular-file-upload/wiki/FAQ)
 4. [Migrate from 0.x.x to 1.x.x](https://github.com/nervgh/angular-file-upload/wiki/Migrate-from-0.x.x-to-1.x.x)
+5. [RubyGem](https://github.com/marthyn/angularjs-file-upload-rails)


### PR DESCRIPTION
Since we're using this with a Rails/AngularJS app we wanted to make a gem out of it. I think more people who use this in combination with Rails could benefit so i added it to the more info bit of the readme.

[RubyGem](https://github.com/Marthyn/angularjs-file-upload-rails)
