### PR TITLE
when mouse move fast, could be not equal.

### DIFF
--- a/angular-file-upload.js
+++ b/angular-file-upload.js
@@ -1155,7 +1155,7 @@ module
              * Event handler
              */
             FileDrop.prototype.onDragLeave = function(event) {
-                if (event.target !== this.element[0]) return;
+                //if (event.target !== this.element[0]) return;
                 this._preventAndStop(event);
                 angular.forEach(this.uploader._directives.over, this._removeOverClass, this);
             };


### PR DESCRIPTION
when mouse move fast between drag area and out of browser, event.target and element[0] could be not equal.
so It shouldn't be returned and the overClass should be removed.
