### PR TITLE
fix(iframe): fix handling of res:// error for <=IE9 to have the possibil...

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -493,6 +493,8 @@ module
                 var iframe = angular.element('<iframe name="iframeTransport' + Date.now() + '">');
                 var input = item._input;
                 var that = this;
+                var html;
+                var responseStatus = 200;
 
                 if (item._form) item._form.replaceWith(input); // remove old form
                 item._form = form; // save link to new form
@@ -529,10 +531,14 @@ module
                         // returning response via same 'success' event handler.
 
                         // fixed angular.contents() for iframes
-                        var html = iframe[0].contentDocument.body.innerHTML;
-                    } catch (e) {}
+                        html = iframe[0].contentDocument.body.innerHTML;
+                    } catch (e) {
+                        // in case we run into the access-is-denied error or we have another error on the server side
+                        // (intentional 500,40... errors), we at least say 'something went wrong' -> 500
+                        responseStatus = 500;
+                    }
 
-                    var xhr = {response: html, status: 200, dummy: true};
+                    var xhr = {response: html, status: responseStatus, dummy: true};
                     var response = that._transformResponse(xhr.response);
                     var headers = {};
 


### PR DESCRIPTION
...ity to handle it from within the client app

This patch helps an application to roughly detect that the server responded with an error and not a status of 200.

Also it fixes one bug: html was out of scope for 
```
var xhr = {response: html, status: 200, dummy: true};
```

as html was defined inside the structure above of that in the try block. 