### PR TITLE
enable ie9 to transport complex form data

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -503,7 +503,9 @@ module
 
                 angular.forEach(item.formData, function(obj) {
                     angular.forEach(obj, function(value, key) {
-                        form.append(angular.element('<input type="hidden" name="' + key + '" value="' + value + '" />'));
+                        var element = angular.element('<input type="hidden" name="' + key + '" />');
+                        element.val(value);
+                        form.append(element);
                     });
                 });
 


### PR DESCRIPTION
Currently form data is appended to iframe forms by simple string interpolation.  The breaks down if you're trying to send a JSON or other complex field – for instance angular.toJson uses double quotes to identify strings, which breaks down in the current implementation.  This fix uses the standard angular/jqLite implementation to set the value in a sanitized way.
