### PR TITLE
Add failsafe to avoid flickering due to spurious out events

### DIFF
--- a/angular-file-upload.js
+++ b/angular-file-upload.js
@@ -1221,6 +1221,8 @@ module
              */
             function FileOver(options) {
                 FileOver.super_.apply(this, arguments);
+
+                this.removeClassTimeout = -1;
             }
             /**
              * Map of events
@@ -1243,13 +1245,22 @@ module
              * Adds over class
              */
             FileOver.prototype.addOverClass = function() {
+                if (this.removeClassTimeout > -1) {
+                    clearTimeout(this.removeClassTimeout);
+                    this.removeClassTimeout = -1;
+                }
                 this.element.addClass(this.getOverClass());
             };
             /**
              * Removes over class
              */
             FileOver.prototype.removeOverClass = function() {
-                this.element.removeClass(this.getOverClass());
+                var self=this;
+                if (self.removeClassTimeout < 0) {
+                    self.removeClassTimeout = setTimeout(function() {
+                        self.element.removeClass(self.getOverClass());
+                    },50);
+                }
             };
             /**
              * Returns over class

--- a/src/module.js
+++ b/src/module.js
@@ -1205,6 +1205,8 @@ module
              */
             function FileOver(options) {
                 FileOver.super_.apply(this, arguments);
+
+                this.removeClassTimeout = -1;
             }
             /**
              * Map of events
@@ -1227,13 +1229,22 @@ module
              * Adds over class
              */
             FileOver.prototype.addOverClass = function() {
+                if (this.removeClassTimeout > -1) {
+                    clearTimeout(this.removeClassTimeout);
+                    this.removeClassTimeout = -1;
+                }
                 this.element.addClass(this.getOverClass());
             };
             /**
              * Removes over class
              */
             FileOver.prototype.removeOverClass = function() {
-                this.element.removeClass(this.getOverClass());
+                var self=this;
+                if (self.removeClassTimeout < 0) {
+                    self.removeClassTimeout = setTimeout(function() {
+                        self.element.removeClass(self.getOverClass());
+                    },50);
+                }
             };
             /**
              * Returns over class


### PR DESCRIPTION
I fought with this for a couple of hours to find a cleaner fix, but this seems to be the best option. There are actually some browsers (Chrome and Safari on Mac specifically) where in some cases I received dragleave events more frequently than dragover events.  

- On certain pages I actually get more out events than I do over events;
  drop still works fine, but I get lots of flickering on the page.  With
  this change as long as those events aren't slower than 50ms it doesn't
  happen, but 50ms is still short enough it's not really noticeable.