### PR TITLE
Pass File object to filters if supported

### DIFF
--- a/angular-file-upload.js
+++ b/angular-file-upload.js
@@ -89,7 +89,7 @@ module
                 var addedFileItems = [];
 
                 angular.forEach(list, function(some /*{File|HTMLInputElement|Object}*/) {
-                    var temp = new FileUploader.FileLikeObject(some);
+                    var temp = FileUploader.isFile(some) ? some : new FileUploader.FileLikeObject(some);
 
                     if (this._isValidFile(temp, arrayOfFilters, options)) {
                         var fileItem = new FileUploader.FileItem(this, some, options);


### PR DESCRIPTION
Pass the original `File` object to the filters if the browser gave us a `File` object. Otherwise, give the filter a `FileLikeObject`. This enables complex filters that need use of the `File` object directly.