### PR TITLE
formData fix on uploader

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -446,9 +446,7 @@ module
                 that._onBeforeUploadItem(item);
 
                 angular.forEach(item.formData, function(obj) {
-                    angular.forEach(obj, function(value, key) {
-                        form.append(key, value);
-                    });
+                    form.append(key, value);
                 });
 
                 form.append(item.alias, item._file, item.file.name);


### PR DESCRIPTION
Additional FormData for files was being looped twice causing form data
to be sent as individual characters in an array. This fixes that issue
and now form data on the upload is an Object instead of an array stated
in the Docs. You would have to ix the documentation as well stating
that formData is an Object containing key/value pairs to be uploaded as
part of the request body.