### PR TITLE
fix filter select for onWhenAddingFileFailed() callback

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -81,7 +81,7 @@ module
                         this.queue.push(fileItem);
                         this._onAfterAddingFile(fileItem);
                     } else {
-                        var filter = this.filters[this._failFilterIndex];
+                        var filter = arrayOfFilters[this._failFilterIndex];
                         this._onWhenAddingFileFailed(temp, filter, options);
                     }
                 }, this);


### PR DESCRIPTION
Failed filter index is calculated for user provided filters list so when
notifying onWhenAddingFileFailed(), this failed filter also must be taken
from user provided filters list. Otherwise wrong filter will be passed.