### PR TITLE
in derived classes, super() should be called before

### DIFF
--- a/src/services/FileDrop.js
+++ b/src/services/FileDrop.js
@@ -10,8 +10,8 @@ let {
 
 
 export default (FileDirective) => {
-    
-    
+
+
     class FileDrop extends FileDirective {
         /**
          * Creates instance of {FileDrop} object
@@ -19,6 +19,8 @@ export default (FileDirective) => {
          * @constructor
          */
         constructor(options) {
+            super(options);
+
             // Map of events
             this.events = {
                 $destroy: 'destroy',
@@ -28,8 +30,6 @@ export default (FileDirective) => {
             };
             // Name of property inside uploader._directive object
             this.prop = 'drop';
-            
-            super(options);
         }
         /**
          * Returns options
@@ -113,8 +113,8 @@ export default (FileDirective) => {
             item.removeOverClass();
         }
     }
-    
-    
+
+
     return FileDrop;
 }
 

--- a/src/services/FileOver.js
+++ b/src/services/FileOver.js
@@ -5,8 +5,8 @@ import CONFIG from './../config.json';
 
 
 export default (FileDirective) => {
-    
-    
+
+
     class FileOver extends FileDirective {
         /**
          * Creates instance of {FileDrop} object
@@ -14,6 +14,8 @@ export default (FileDirective) => {
          * @constructor
          */
         constructor(options) {
+            super(options);
+            
             // Map of events
             this.events = {
                 $destroy: 'destroy'
@@ -22,8 +24,6 @@ export default (FileDirective) => {
             this.prop = 'over';
             // Over class
             this.overClass = 'nv-file-over';
-            
-            super(options);
         }
         /**
          * Adds over class
@@ -45,8 +45,8 @@ export default (FileDirective) => {
             return this.overClass;
         }
     }
-    
-    
+
+
     return FileOver;
 }
 

--- a/src/services/FileSelect.js
+++ b/src/services/FileSelect.js
@@ -5,8 +5,8 @@ import CONFIG from './../config.json';
 
 
 export default (FileDirective) => {
-    
-    
+
+
     class FileSelect extends FileDirective {
         /**
          * Creates instance of {FileSelect} object
@@ -14,6 +14,8 @@ export default (FileDirective) => {
          * @constructor
          */
         constructor(options) {
+            super(options);
+
             // Map of events
             this.events = {
                 $destroy: 'destroy',
@@ -21,9 +23,7 @@ export default (FileDirective) => {
             };
             // Name of property inside uploader._directive object
             this.prop = 'select';
-            
-            super(options);
-            
+
             if(!this.uploader.isHTML5) {
                 this.element.removeAttr('multiple');
             }
@@ -61,8 +61,8 @@ export default (FileDirective) => {
             if(this.isEmptyAfterSelection()) this.element.prop('value', null);
         }
     }
-    
-    
+
+
     return FileSelect;
 }
 


### PR DESCRIPTION
In derived classes, super() should be called before `this`, since it causes errors when compiling with Babel.