### PR TITLE
Allow BeforeUploadItem event to cancel upload

### DIFF
--- a/src/services/FileUploader.js
+++ b/src/services/FileUploader.js
@@ -431,6 +431,7 @@ export default function __identity(fileUploaderOptions, $rootScope, $http, $wind
             if (!this._onBeforeUploadItem(item)) {
                 this._onCancelItem(item);
                 this._onCompleteItem(item);
+                return;
             }
 
             if (!item.disableMultipart) {
@@ -506,6 +507,7 @@ export default function __identity(fileUploaderOptions, $rootScope, $http, $wind
             if (!this._onBeforeUploadItem(item)) {
                 this._onCancelItem(item);
                 this._onCompleteItem(item);
+                return;
             }
 
             input.prop('name', item.alias);

--- a/src/services/FileUploader.js
+++ b/src/services/FileUploader.js
@@ -117,6 +117,7 @@ export default function __identity(fileUploaderOptions, $rootScope, $http, $wind
 
             this.isUploading = true;
             this[transport](item);
+            this._render();
         }
         /**
          * Cancels uploading of item from the queue
@@ -230,6 +231,7 @@ export default function __identity(fileUploaderOptions, $rootScope, $http, $wind
          * @param {FileItem} fileItem
          */
         onBeforeUploadItem(fileItem) {
+            return true;
         }
         /**
          * Callback
@@ -426,7 +428,10 @@ export default function __identity(fileUploaderOptions, $rootScope, $http, $wind
             var xhr = item._xhr = new XMLHttpRequest();
             var sendable;
 
-            this._onBeforeUploadItem(item);
+            if (!this._onBeforeUploadItem(item)) {
+                this._onCancelItem(item);
+                this._onCompleteItem(item);
+            }
 
             if (!item.disableMultipart) {
                 sendable = new FormData();
@@ -498,7 +503,10 @@ export default function __identity(fileUploaderOptions, $rootScope, $http, $wind
             if(item._form) item._form.replaceWith(input); // remove old form
             item._form = form; // save link to new form
 
-            this._onBeforeUploadItem(item);
+            if (!this._onBeforeUploadItem(item)) {
+                this._onCancelItem(item);
+                this._onCompleteItem(item);
+            }
 
             input.prop('name', item.alias);
 
@@ -599,7 +607,7 @@ export default function __identity(fileUploaderOptions, $rootScope, $http, $wind
          */
         _onBeforeUploadItem(item) {
             item._onBeforeUpload();
-            this.onBeforeUploadItem(item);
+            return this.onBeforeUploadItem(item);
         }
         /**
          * Inner callback


### PR DESCRIPTION
This change allows the onBeforeUploadItem event handler to cancel the upload by returning false.