### PR TITLE
FormData.append does not implement interface Blob

### DIFF
--- a/src/services/FileItem.js
+++ b/src/services/FileItem.js
@@ -48,7 +48,7 @@ export default function __identity($compile, FileLikeObject) {
                 isError: false,
                 progress: 0,
                 index: null,
-                _file: file,
+                _file: (file instanceof Blob) ? file : new Blob([file]),
                 _input: input
             });
 


### PR DESCRIPTION
I had the following code

..... = new FileUploader.FileItem(uploader, {
                        size: 1e6,
                        name: name,
                        progress: 0,
                        isUploaded: false,
                        isSuccess: false
                    });

In chrome it is working great but in mozilla i get the following exception

Error: Argument 2 of FormData.append does not implement interface Blob.
I ended up at method " FileUploader.prototype._xhrTransport " and line 705

var sendable = new FormData();
......
sendable.append() method needs the second argument to be Blob, but now my code sends an object.

So i had either to do 

..... = new FileUploader.FileItem(uploader, new Blob([{
                        size: 1e6,
                        name: name,
                        progress: 0,
                        isUploaded: false,
                        isSuccess: false
                    }]));

or fix it in FileItem constructor.