### PR TITLE
Added support for setting XHR responseType

### DIFF
--- a/src/services/FileItem.js
+++ b/src/services/FileItem.js
@@ -35,6 +35,7 @@ export default function __identity($compile, FileLikeObject) {
                 formData: copy(uploader.formData),
                 removeAfterUpload: uploader.removeAfterUpload,
                 withCredentials: uploader.withCredentials,
+                responseType: uploader.responseType,
                 disableMultipart: uploader.disableMultipart,
                 method: uploader.method
             }, options, {

--- a/src/services/FileUploader.js
+++ b/src/services/FileUploader.js
@@ -510,6 +510,7 @@ export default function __identity(fileUploaderOptions, $rootScope, $http, $wind
             xhr.open(item.method, item.url, true);
 
             xhr.withCredentials = item.withCredentials;
+            xhr.responseType = item.responseType;
 
             forEach(item.headers, (value, name) => {
                 xhr.setRequestHeader(name, value);


### PR DESCRIPTION
This PR adds support for setting the [`responseType` property of the  `XMLHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType).

You might want to use this if you want to return a binary file, eg a zip or pdf after upload. In this case you want to set the `responseType` to `blob`.
