### PR TITLE
Allow exception data to pass through to the onErrorItem and onCompleteItem callbacks

### DIFF
--- a/src/services/FileItem.js
+++ b/src/services/FileItem.js
@@ -64,8 +64,9 @@ export default function __identity($compile, FileLikeObject) {
             try {
                 this.uploader.uploadItem(this);
             } catch(e) {
-                this.uploader._onCompleteItem(this, '', 0, []);
-                this.uploader._onErrorItem(this, '', 0, []);
+                var message = e.name + ':' + e.message;
+                this.uploader._onCompleteItem(this, message, e.code, []);
+                this.uploader._onErrorItem(this, message, e.code, []);
             }
         }
         /**


### PR DESCRIPTION
Allow the exception reason to pass through to the onErrorItem and onCompleteItem callbacks.

I think it is useful since it allows the client to figure out what could have failed.

I was attempting to add invalid header data.  In this case adding an emoji to a header  value ("😀") results in e being:

```
code: 12,
message:"Failed to execute 'setRequestHeader' on 'XMLHttpRequest': '😀' is not a valid HTTP header field value."
name:"SyntaxError"
stack: <removed>
```

If I could detect code 12 then I'd be able to address it to the user correctly.  A very chance of occurring but a chance nonetheless.