### PR TITLE
Adding license info to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.5.0",
   "homepage": "https://github.com/nervgh/angular-file-upload",
   "description": "Angular File Upload is a module for the AngularJS framework",
+  "license": "MIT",
   "author": {
     "name": "nerv",
     "url": "https://github.com/nervgh"


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding to the license info to the package.json it's much easier for OS tools to read out the license info and that way the license info is available through the public NPMRegistry API. 