### PR TITLE
Add export default to export module name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import directiveFileDrop from './directives/FileDrop';
 import directiveFileOver from './directives/FileOver';
 
 
-angular
+export default angular
     .module(CONFIG.name, [])
     .value('fileUploaderOptions', options)
     .factory('FileUploader', serviceFileUploader)
@@ -55,4 +55,5 @@ angular
             FileUploader.FileOver = FileOver;
             FileUploader.Pipeline = Pipeline;
         }
-    ]);
+    ])
+    .name;


### PR DESCRIPTION
Now we should be able to do

```js
import ngFileUpload from 'angular-file-upload'

angular.module('moduleName', [ngFileUpload])
```